### PR TITLE
Fix: Ensure partial download button appears after cancellation

### DIFF
--- a/whois_lookup.py
+++ b/whois_lookup.py
@@ -368,6 +368,7 @@ def process_and_display_domains(valid_domains, lookup_type, timeout, rate_limit)
 
     if st.button("Cancel"):
         st.session_state.processing = False
+        st.session_state.all_lookups_successful = False # Add this line
         st.warning("Cancelling operation...")
 
     for idx, domain in enumerate(valid_domains, 1):


### PR DESCRIPTION
When you click the 'Cancel' button during WHOIS lookups, the `all_lookups_successful` flag in the session state was not being explicitly updated to reflect the incomplete nature of the results. This prevented the 'Download partial results as CSV' button from appearing as intended.

This commit modifies the cancel logic in `process_and_display_domains` to explicitly set `st.session_state.all_lookups_successful = False` when the cancel button is pressed. This ensures that the correct conditional logic in the `main` function is triggered to display the partial download button if any results were processed before cancellation.